### PR TITLE
Prevent setting layout/config options affect global defaults

### DIFF
--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -116,8 +116,8 @@ mutable struct Plot
 
     function Plot(
             data::Union{Config, Vector{Config}},
-            layout::Config = Defaults.layout[],
-            config::Config = Defaults.config[];
+            layout::Config = copy(Defaults.layout[]),
+            config::Config = copy(Defaults.config[]);
             # kw
             id::AbstractString = randstring(10),
             js::Cobweb.Javascript = Cobweb.Javascript("console.log('plot created!')")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using PlotlyLight
+using PlotlyLight.Defaults
 using JSON3
 using Test
 
@@ -11,6 +12,18 @@ using Test
     @test isempty(only(p.data))
     p(Config(x=1:10,y=rand(10)))
     @test length(p.data) == 2
+end
+#-----------------------------------------------------------------------------# defaults
+@testset "defaults" begin
+    old_layout_default = copy(Defaults.layout[])
+    old_config_default = copy(Defaults.config[])
+    p = Plot()
+    p.layout.xaxis.showgrid = false
+    p.config.editable = true
+    # make sure that mutation of layout and config of one plot has no effect on
+    # global defaults
+    @test Defaults.layout[] == old_layout_default
+    @test Defaults.config[] == old_config_default
 end
 #-----------------------------------------------------------------------------# src
 @testset "src" begin


### PR DESCRIPTION
Previously, in code like this:
```julia
p1 = Plot()
p1.layout.xaxis.showgrid = false

p2 = Plot()
```
`p2` would also have no x-grid, even if we wanted that only for `p1`. The reason is that both use the default layout which we mutate in the second line, although we actually only want to mutate the layout of `p1`.

This PR fixes this problem by copying the defaults for `layout` and `config` in the constructor of `Plot`.