### PR TITLE
update to show plots within Jupyter notebook in VSCode instead of browser

### DIFF
--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -258,13 +258,7 @@ function page(o::Plot)
     ))
 end
 
-function Base.display(::Cobweb.CobwebDisplay, o::Plot) 
-    if (~isinteractive() && isdefined(Main, :VSCodeServer)) # VSCode Jupyter
-        display(HTML(repr("text/html", o)));
-    else
-        display(Cobweb.CobwebDisplay(), page(o))
-    end
-end
+Base.display(::Cobweb.CobwebDisplay, o::Plot) = display(Cobweb.CobwebDisplay(), page(o))
 
 Base.show(io::IO, ::MIME"juliavscode/html", o::Plot) = show(io, MIME"text/html"(), o)
 

--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -198,10 +198,13 @@ module Preset
 
         pluto!(r = true) = settings!(r, config=Config(height="100%", width="100%"))
 
+        vscodejupyter!(r = true;) = iframe!(r; width="750px", scrolling="no");
+
         function auto!(r = true, io::IO = stdout)
             :pluto in keys(io) ? pluto!(r) :
             (isdefined(Main, :IJulia) && io isa Main.IJulia.IJuliaStdio) || :jupyter in keys(io) ? iframe!(r) :
             isinteractive() ? fillwindow!(r) :
+            isdefined(Main, :VSCodeServer) ? vscodejupyter!(r) : # VSCode Jupyter ] isinteractive() = false ])
             nothing
         end
     end
@@ -252,7 +255,13 @@ function page(o::Plot)
     ))
 end
 
-Base.display(::Cobweb.CobwebDisplay, o::Plot) = display(Cobweb.CobwebDisplay(), page(o))
+function Base.display(::Cobweb.CobwebDisplay, o::Plot) 
+    if (~isinteractive() && isdefined(Main, :VSCodeServer)) # VSCode Jupyter
+        display(HTML(repr("text/html", o)));
+    else
+        display(Cobweb.CobwebDisplay(), page(o))
+    end
+end
 
 Base.show(io::IO, ::MIME"juliavscode/html", o::Plot) = show(io, MIME"text/html"(), o)
 

--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -104,7 +104,7 @@ Base.@kwdef mutable struct Settings
     layout::Config      = Config()
     config::Config      = Config()
     iframe::Union{Nothing, Cobweb.IFrame} = nothing
-    display_object::Union{Type{Cobweb.Page}, Type{Cobweb.Tab}} = Cobweb.Page
+    display_object::Union{Type{Cobweb.IFrame}, Type{Cobweb.Page}, Type{Cobweb.Tab}} = Cobweb.Page
 end
 function Base.show(io::IO, o::Settings)
     println(io, "PlotlyLight.Settings:")
@@ -198,7 +198,10 @@ module Preset
 
         pluto!(r = true) = settings!(r, config=Config(height="100%", width="100%"))
 
-        vscodejupyter!(r = true;) = iframe!(r; width="750px", scrolling="no");
+        function vscodejupyter!(r = true;)
+            iframe!(r; width="750px", scrolling="no");
+            settings!(false; display_object=Cobweb.IFrame)
+        end
 
         function auto!(r = true, io::IO = stdout)
             :pluto in keys(io) ? pluto!(r) :

--- a/src/PlotlyLight.jl
+++ b/src/PlotlyLight.jl
@@ -199,7 +199,7 @@ module Preset
         pluto!(r = true) = settings!(r, config=Config(height="100%", width="100%"))
 
         function vscodejupyter!(r = true;)
-            iframe!(r; width="750px", scrolling="no");
+            iframe!(r; width="750px", scrolling="no")
             settings!(false; display_object=Cobweb.IFrame)
         end
 


### PR DESCRIPTION
resolves #34

- added `auto!()` container case for Jupyter running in VSCode to use IFrame without scrolling
- updated display function to show different output in this case