### PR TITLE
fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ using PlotlyLight
 
 preset.template.plotly_dark!()  # Change template
 
-p = plot(x = 1:20, y = cumsum(randn(20)), type="scatter", mode="lines+markers")  # Make plot
+p = plot(x = 1:20, y = cumsum(randn(20)), type=:scatter, mode="lines+markers")  # Make plot
 
 p.layout.title.text = "My Title!"  # Make changes
 


### PR DESCRIPTION
The example in README.md was not functioning as the [plot](https://github.com/JuliaComputing/PlotlyLight.jl/blob/fb1386134d96cf8b2e59ee9e8dd0ff9b874c2f8b/src/PlotlyLight.jl#L79C1-L79C54) function was expecting a symbol for plot type and not string. This PR addresses that example. 

