### PR TITLE
Make stdlib compats less specific

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,13 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Aqua = "0.8"
-Artifacts = "1.3"
+Artifacts = "1"
 Cobweb = "0.6, 0.7"
-Dates = "1.11.0"
+Dates = "1"
 Downloads = "1.6"
 EasyConfig = "0.1"
 JSON3 = "1.14"
-REPL = "1.11.0"
+REPL = "1"
 julia = "1.7"
 
 [extras]


### PR DESCRIPTION
Realized there was an issue with Documentation CI job in https://github.com/disberd/PlotlyDocumenter.jl/pull/5.

It seems the auto-compat feature has actually been detrimental for stdlibs here, effectively raising the to 1.11 the julia compat for PlotlyLight version 0.11.1 

REPL and Dates were higher than julia compat entries effectively restricting julia compat.

Artifacts was already lower than julia compat so leaving it as "1" would not make this problematic